### PR TITLE
Added Environment health status checks in clone and swap steps

### DIFF
--- a/src/clone_blue_environment.py
+++ b/src/clone_blue_environment.py
@@ -1,6 +1,7 @@
 import json
 import time
 import os
+import swap_environment
 
 # noqa: E502
 
@@ -32,6 +33,17 @@ def main(BLUE_ENV_NAME, GREEN_ENV_NAME, BEANSTALK_APP_NAME, S3_ARTIFACTS_BUCKET,
         )
 
         print("Green environment ID: " + green_env_id)
+        print("Wating for the Green environment to be Ready and Healthy\n")
+
+        green_env_info, beanstalkclient = swap_environment.get_environment_information(
+        beanstalkclient, GREEN_ENV_NAME)
+        while ((green_env_info["Environments"][0]["Status"] != "Ready") and (green_env_info["Environments"][0]["Health"] != "Green") and (green_env_info["Environments"][0]["HealthStatus"] != "Ok")):
+            time.sleep(10)
+            green_env_info,beanstalkclient = swap_environment.get_environment_information(
+                beanstalkclient, GREEN_ENV_NAME)
+        
+        print("Green environment is Ready and Healthy\n")
+
         if green_env_id and did_new_env_was_created:
             # Create a CNAME Config file
             blue_env_cname = blue_env_info['Environments'][0]['CNAME']

--- a/src/release_health_check.py
+++ b/src/release_health_check.py
@@ -36,8 +36,8 @@ def get_env_info(beanstalkclient, env_name):
 
 def wait_until_env_be_ready(beanstalkclient, ENV_NAME):
     env_info = get_env_info(beanstalkclient, ENV_NAME)
-    while env_info["Environments"][0]["Status"] != "Ready":
-        print("Waiting the blue environment be Ready!")
+    while ((env_info["Environments"][0]["Status"] != "Ready") and (env_info["Environments"][0]["HealthStatus"] != "Ok")):
+        print("Waiting the blue environment to be Ready and Healthy!")
         time.sleep(10)
         env_info = get_env_info(beanstalkclient, ENV_NAME)
     return "Env is ready"

--- a/src/swap_environment.py
+++ b/src/swap_environment.py
@@ -38,7 +38,7 @@ def main(BLUE_ENV_NAME, GREEN_ENV_NAME, S3_ARTIFACTS_BUCKET, BEANSTALK_APP_NAME,
     if blue_env_url == green_env_cname:
         print("Nothing to swap")
     else:
-        while green_env_info["Environments"][0]["Status"] != "Ready":
+        while ((green_env_info["Environments"][0]["Status"] != "Ready") and (green_env_info["Environments"][0]["Health"] != "Green") and (green_env_info["Environments"][0]["HealthStatus"] != "Ok")):
             time.sleep(10)
             green_env_info = get_environment_information(
                 beanstalkclient, GREEN_ENV_NAME)
@@ -74,7 +74,7 @@ def get_environment_information(beanstalkclient, EnvName):
         time.sleep(60)
 
         if env_count == 3:
-            print(f"Waiting for {EnvName} env to be ready.")
+            print(f"Waiting for {EnvName} env to be ready and Healthy.")
             env_count = 0
         else:
             env_count += 1
@@ -87,7 +87,7 @@ def swap_urls(beanstalkclient, SourceEnv, DestEnv):
     green_env_data = (beanstalkclient.describe_environments(
         EnvironmentNames=[SourceEnv, DestEnv], IncludeDeleted=False))
     print(green_env_data)
-    if (((green_env_data["Environments"][0]["Status"]) == "Ready") and ((green_env_data["Environments"][1]["Status"]) == "Ready")):
+    if (((green_env_data["Environments"][0]["Status"]) == "Ready") and ((green_env_data["Environments"][0]["HealthStatus"]) == "Ok") and ((green_env_data["Environments"][1]["Status"]) == "Ready") and ((green_env_data["Environments"][1]["HealthStatus"]) == "Ok")):
         beanstalkclient.swap_environment_cnames(
             SourceEnvironmentName=SourceEnv, DestinationEnvironmentName=DestEnv)
         return ("Successful")

--- a/src/terminate_green_env.py
+++ b/src/terminate_green_env.py
@@ -14,7 +14,7 @@ def main(BLUE_ENV_NAME, GREEN_ENV_NAME, BEANSTALK_APP_NAME, boto_authenticated_c
         DeleteConfigTemplate=delete_config_template_blue(beanstalkclient, AppName=(BEANSTALK_APP_NAME), TempName=(CREATE_CONFIG_TEMPLATE_NAME))
         print(DeleteConfigTemplate)
         #re-swapping the urls
-        print("Swapping URL's")
+        print("Swapping URL's back!")
         reswap = swap_green_blue(beanstalkclient, SourceEnv=(BLUE_ENV_NAME), DestEnv=(GREEN_ENV_NAME))
         if reswap == "Failure":
             print("Re-Swap did not happen")
@@ -38,7 +38,7 @@ def delete_config_template_blue(beanstalkclient, AppName, TempName):
 
 def swap_green_blue(beanstalkclient, SourceEnv, DestEnv):
     GetEnvData = (beanstalkclient.describe_environments(EnvironmentNames=[SourceEnv,DestEnv],IncludeDeleted=False))
-    if (((GetEnvData['Environments'][0]['Status']) == "Ready") and ((GetEnvData['Environments'][1]['Status']) == "Ready")):
+    if (((GetEnvData['Environments'][0]['Status']) == "Ready") and ((GetEnvData['Environments'][0]['HealthStatus']) == "Ok") and ((GetEnvData['Environments'][1]['Status']) == "Ready") and ((GetEnvData['Environments'][1]['HealthStatus']) == "Ok")):
         response = beanstalkclient.swap_environment_cnames(SourceEnvironmentName=SourceEnv,DestinationEnvironmentName=DestEnv)
         return ("Successful")
     else:


### PR DESCRIPTION
## Issue to resolve:
Current Blue Green deployment is causing applications to go down due to below reason:
- Cloning Green Environment is getting finished but without deploying application version. However, deployment scripts are able to swap the prod url pointing to Green cloned one, which causing application/website down.

## Types of changes:
- [ x] Bugfix (non-breaking change which fixes an issue)

## Further comments

Currently, scripts are checking environment Status Ready only.  As part of this change, Environment Health and HealthStatus checks also added to enure application versions are deployed and instances are Ok to swap the Urls. 